### PR TITLE
Fix kubeconfig loading

### DIFF
--- a/cmd/wcnspect/cmd/commands.go
+++ b/cmd/wcnspect/cmd/commands.go
@@ -86,10 +86,12 @@ func (b *commandsBuilder) newwcnspectCmd() *wcnspectCmd {
 		Use:   "wcnspect",
 		Short: "wcnspect is an advanced distributed packet capture and HNS log collection tool.",
 		Long:  `An advanced distributed packet capture and HNS log collection tool made with Go (^_^)`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cc.initializeAKSClusterValues()
+		},
 	})
 	cc.cmd.PersistentFlags().StringVar(&cc.kubeconfig, "kubeconfig", "", "Specify absolute path to the kubeconfig file.")
 	cc.cmd.CompletionOptions.DisableDefaultCmd = true
-	cc.initializeAKSClusterValues()
 
 	return cc
 }

--- a/manifest/wcnspectserv-daemon.yml
+++ b/manifest/wcnspectserv-daemon.yml
@@ -33,9 +33,7 @@ spec:
       - name: windowswcnspectserver
         image: ghcr.io/microsoft/wcnspect:latest
         command:
-        - powershell.exe
-        - -command
-        - ./wcnspectserv.exe # can add `-p {num}` here to change server's port
+        - /hpc/wcnspectserv.exe # can add `-p {num}` here to change server's port
         securityContext:
           privileged: true
       nodeSelector:


### PR DESCRIPTION
This PR:
- fixes a bug if you pass the kubeconfig it won't work due to flag not being parsed. This moves it to the [PreRun](https://github.com/spf13/cobra/blob/main/user_guide.md#prerun-and-postrun-hooks) so it will get the value from the flag and still run before all commands
- adds InCluster Config support so it can be used inside a container since there is a requirement to be on the same network as the Nodes.